### PR TITLE
Fix use of table.new(); parameters are not optional.

### DIFF
--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -47,7 +47,7 @@ local function get_cookie_table(text_cookie)
         end
     end
 
-    local cookie_table  = new_tab(n + 1)
+    local cookie_table  = new_tab(0, n + 1)
 
     local state = EXPECT_SP
     local i = 1


### PR DESCRIPTION
The LuaJIT 2.1 table.new() function has two parameters: narr and nrec. It
is not possible to omit either. The code was assuming that this was possible.
