### PR TITLE
Implement support for SameSite attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Synopsis
                     key = "Name", value = "Bob", path = "/",
                     domain = "example.com", secure = true, httponly = true,
                     expires = "Wed, 09 Jun 2021 10:18:14 GMT", max_age = 50,
-                    extension = "a4334aebaec"
+                    samesite = "Strict", extension = "a4334aebaec"
                 })
                 if not ok then
                     ngx.log(ngx.ERR, err)
@@ -122,6 +122,7 @@ syntax: ok, err = cookie_obj:set({
     secure = true, httponly = true,
     expires = "Wed, 09 Jun 2021 10:18:14 GMT",
     max_age = 50,
+    samesite = "Strict",
     extension = "a4334aebaec"
 })
 ```

--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -8,6 +8,7 @@ local sub           = string.sub
 local format        = string.format
 local log           = ngx.log
 local ERR           = ngx.ERR
+local WARN          = ngx.WARN
 local ngx_header    = ngx.header
 
 local EQUAL         = byte("=")
@@ -136,6 +137,17 @@ local function bake(cookie)
     if cookie["max-age"] then
         cookie.max_age = cookie["max-age"]
     end
+
+	if (cookie.samesite) then
+		local samesite = cookie.samesite
+
+		-- if we dont have a valid-looking attribute, ignore the attribute
+		if (samesite ~= "Strict" and samesite ~= "Lax") then
+			log(WARN, "SameSite value must be 'Strict' or 'Lax'")
+			cookie.samesite = nil
+		end
+	end
+
     local str = cookie.key .. "=" .. cookie.value
         .. (cookie.expires and "; Expires=" .. cookie.expires or "")
         .. (cookie.max_age and "; Max-Age=" .. cookie.max_age or "")
@@ -143,6 +155,7 @@ local function bake(cookie)
         .. (cookie.path and "; Path=" .. cookie.path or "")
         .. (cookie.secure and "; Secure" or "")
         .. (cookie.httponly and "; HttpOnly" or "")
+        .. (cookie.samesite and "; SameSite=" .. cookie.samesite or "")
         .. (cookie.extension and "; " .. cookie.extension or "")
     return str
 end

--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -138,15 +138,15 @@ local function bake(cookie)
         cookie.max_age = cookie["max-age"]
     end
 
-	if (cookie.samesite) then
-		local samesite = cookie.samesite
+    if (cookie.samesite) then
+        local samesite = cookie.samesite
 
-		-- if we dont have a valid-looking attribute, ignore the attribute
-		if (samesite ~= "Strict" and samesite ~= "Lax") then
-			log(WARN, "SameSite value must be 'Strict' or 'Lax'")
-			cookie.samesite = nil
-		end
-	end
+        -- if we dont have a valid-looking attribute, ignore the attribute
+        if (samesite ~= "Strict" and samesite ~= "Lax") then
+            log(WARN, "SameSite value must be 'Strict' or 'Lax'")
+            cookie.samesite = nil
+        end
+    end
 
     local str = cookie.key .. "=" .. cookie.value
         .. (cookie.expires and "; Expires=" .. cookie.expires or "")


### PR DESCRIPTION
SameSite is an update to RFC6265, allowing servers to assert
that user agents should not send certain cookies along with
cross-site requests.

See: https://tools.ietf.org/html/draft-west-first-party-cookies-07