### PR TITLE
patch solving problem with broken cookies without "="

### DIFF
--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -65,6 +65,13 @@ local function get_cookie_table(text_cookie)
                 key = sub(text_cookie, i, j - 1)
                 state = EXPECT_VALUE
                 i = j + 1
+            elseif byte(text_cookie, j) == SEMICOLON then
+                value = sub(text_cookie, i, j - 1)
+                cookie_table[""] = value
+
+                key, value = nil, nil
+                state = EXPECT_SP
+                i = j + 1
             end
         elseif state == EXPECT_VALUE then
             if byte(text_cookie, j) == SEMICOLON


### PR DESCRIPTION
Patch fixes problem when for some reason browser has broken cookie without "=" sign, generated as example from script below:
<?  
header("Set-Cookie: verybadcookie;");  
setcookie("silexsession","idnum");  
?>  
Safari just ignore cookies like that,  but opera, firefox and chrome save them as value with null key. IE sends them without key but present internal as cookie1, cookie2 and so on.
The real problem occurs when after broken cookie there is some real one, because library parses thees two cookies from example as one with key="verybadcookie; silexsession" and value="idnum".
It is quite unlike situation, but it took me long time to find out why one of my LUA scripts sometimes were going crazy. 
