### PR TITLE
New method to get all cookies including multiple cookies with same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Table of Contents
     * [new](#new)
     * [get](#get)
     * [get_all](#get_all)
+    * [get_all_as_list](#get_all_as_list)
     * [set](#set)
 * [Installation](#installation)
 * [Authors](#authors)
@@ -55,6 +56,22 @@ Synopsis
 
                 for k, v in pairs(fields) do
                     ngx.say(k, " => ", v)
+                end
+
+                -- get all cookies as list
+                -- This method is introduced to handle multiple cookies with same name. An HTTP request can
+                -- have multiple cookies with same name when they have different PATH or different
+                -- DOMAIN(a sub domain). For e.g. Cookies created by example.com domain will be accessible
+                -- to test.example.com
+                local cookies, err = cookie:get_all_as_list()
+                if not cookies then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                for i=1,#cookies do
+                    local cookie = cookies[i]
+                    ngx.say(cookie["name"].."=>"..cookie["value"])
                 end
 
                 -- set one cookie
@@ -108,6 +125,16 @@ get_all
 `syntax: fields, err = cookie_obj:get_all()`
 
 Get all client cookie key/value pairs in a lua table. On error, returns `nil` and an error message.
+
+[Back to TOC](#table-of-contents)
+
+get_all_as_list
+---------------
+`syntax: cookies, err = cookie_obj:get_all_as_list()`
+
+Get all client cookie key/value pairs in a lua table as list of cookies. The list also includes multiple cookies with the same name. On error, returns `nil` and an error message.
+
+*get_all* will override the previous cookie value with latest cookie value when request has mutliple cookies with same name.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Synopsis
                 end
 
                 for i=1,#cookies do
-                    local cookie = cookies[i]
-                    ngx.say(cookie["name"].."=>"..cookie["value"])
+                    local cookie_item = cookies[i]
+                    ngx.say(cookie_item["name"].."=>"..cookie_item["value"])
                 end
 
                 -- set one cookie

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Synopsis
 
                 for i=1,#cookies do
                     local cookie_item = cookies[i]
-                    ngx.say(cookie_item["name"].."=>"..cookie_item["value"])
+                    ngx.say(cookie_item["name"], " => ", cookie_item["value"])
                 end
 
                 -- set one cookie

--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -97,6 +97,77 @@ local function get_cookie_table(text_cookie)
     return cookie_table
 end
 
+local function get_cookie_table_list(text_cookie)
+    if type(text_cookie) ~= "string" then
+        log(ERR, format("expect text_cookie to be \"string\" but found %s",
+                type(text_cookie)))
+        return {}
+    end
+
+    local EXPECT_KEY    = 1
+    local EXPECT_VALUE  = 2
+    local EXPECT_SP     = 3
+
+    local n = 0
+    local len = #text_cookie
+
+    for i=1, len do
+        if byte(text_cookie, i) == SEMICOLON then
+            n = n + 1
+        end
+    end
+
+    local cookie_table_list  = new_tab(0, n + 1)
+
+    local state = EXPECT_SP
+    local i = 1
+    local j = 1
+    local count = 0
+    local key, value, cookie
+
+    while j <= len do
+        if state == EXPECT_KEY then
+            if byte(text_cookie, j) == EQUAL then
+                cookie = new_tab(0,2)
+                count = count + 1
+                key = sub(text_cookie, i, j - 1)
+                cookie["name"] = key
+                state = EXPECT_VALUE
+                i = j + 1
+            end
+        elseif state == EXPECT_VALUE then
+            if byte(text_cookie, j) == SEMICOLON
+                    or byte(text_cookie, j) == SPACE
+                    or byte(text_cookie, j) == HTAB
+            then
+                value = sub(text_cookie, i, j - 1)
+                cookie["value"] = value
+                cookie_table_list[count] = cookie
+
+                key, value, cookie = nil, nil, nil
+                state = EXPECT_SP
+                i = j + 1
+            end
+        elseif state == EXPECT_SP then
+            if byte(text_cookie, j) ~= SPACE
+                and byte(text_cookie, j) ~= HTAB
+            then
+                state = EXPECT_KEY
+                i = j
+                j = j - 1
+            end
+        end
+        j = j + 1
+    end
+
+    if key ~= nil and value == nil then
+        cookie["value"] = sub(text_cookie, i)
+        cookie_table_list[count] = cookie
+    end
+
+    return cookie_table_list
+end
+
 function _M.new(self)
     local _cookie = ngx.var.http_cookie
     --if not _cookie then
@@ -127,6 +198,18 @@ function _M.get_all(self)
     end
 
     return self.cookie_table
+end
+
+function _M.get_all_as_list(self)
+    if not self._cookie then
+        return nil, "no cookie found in the current request"
+    end
+
+    if self.cookie_table_list == nil then
+        self.cookie_table_list = get_cookie_table_list(self._cookie)
+    end
+
+    return self.cookie_table_list
 end
 
 local function bake(cookie)


### PR DESCRIPTION
Added new method get_all_as_list to retrieve cookies as a lua table list of cookies from HTTP request including multiple cookies with same name.

An HTTP request can have multiple cookies with same name when they have different PATH or different DOMAIN(a sub domain). For e.g. Cookies created by example.com domain will be accessible to test.example.com
``` 
Cookie #1 : name="SAMPLE", value="ABC", path ="/", domain="example.com"
Cookie #2 : name="SAMPLE", value="XYZ", path ="/account", domain="example.com"

Cookie #1 : name="SAMPLE", value="ABC", path ="/", domain="test.example.com"
Cookie #2 : name="SAMPLE", value="XYZ", path ="/", domain="example.com" 
```
The existing *get_all* will override the previous cookie value with the latest value when we have multiple cookies with same name.

There is some duplication of code as I don't want to disturb the existing functionality and also to maintain backward compatibility.

Let me know your thoughts on this so that I can add test cases for the new method.