### PR TITLE
Fixes the problem of cookie parsing confusion

### DIFF
--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -68,7 +68,6 @@ local function get_cookie_table(text_cookie)
             end
         elseif state == EXPECT_VALUE then
             if byte(text_cookie, j) == SEMICOLON
-                    or byte(text_cookie, j) == SPACE
                     or byte(text_cookie, j) == HTAB
             then
                 value = sub(text_cookie, i, j - 1)


### PR DESCRIPTION
Example: VisitorID=602-0c27c4434c19&Exp=12/11/2020 5:49:05 PM
It's a little bit of a little bit of a little bit of a little bit of a little bit of a little bit of a little bit of a little bit of a little bit of a crazy thing