### PR TITLE
Add `None` as a valid `SameSite` value

### DIFF
--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -142,8 +142,8 @@ local function bake(cookie)
         local samesite = cookie.samesite
 
         -- if we dont have a valid-looking attribute, ignore the attribute
-        if (samesite ~= "Strict" and samesite ~= "Lax") then
-            log(WARN, "SameSite value must be 'Strict' or 'Lax'")
+        if (samesite ~= "Strict" and samesite ~= "Lax" and samesite ~= "None") then
+            log(WARN, "SameSite value must be 'Strict', 'Lax' or 'None'")
             cookie.samesite = nil
         end
     end

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -337,10 +337,43 @@ GET /t
 --- no_error_log
 [error]
 --- error_log
-SameSite value must be 'Strict' or 'Lax'
+SameSite value must be 'Strict', 'Lax' or 'None'
 --- response_headers
 Set-Cookie: Name=Bob; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Max-Age=50; Domain=example.com; Path=/; Secure; HttpOnly; a4334aebaec
 --- response_body
 Set cookie
 
 
+=== TEST 10: set cookie with None as a valid SameSite attribute
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local ck = require "resty.cookie"
+            local cookie, err = ck:new()
+            if not cookie then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local ok, err = cookie:set({
+                key = "Name", value = "Bob", path = "/",
+                domain = "example.com", secure = true, httponly = true,
+                expires = "Wed, 09 Jun 2021 10:18:14 GMT", max_age = 50,
+                samesite = "None", extension = "a4334aebaec"
+            })
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            ngx.say("Set cookie")
+        ';
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_headers
+Set-Cookie: Name=Bob; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Max-Age=50; Domain=example.com; Path=/; Secure; HttpOnly; SameSite=None; a4334aebaec
+--- response_body
+Set cookie


### PR DESCRIPTION
Following https://github.com/cloudflare/lua-resty-cookie/pull/12, this PR allows for cookies to have their attribute `SameSite` set to `None`.

See: https://tools.ietf.org/html/draft-west-first-party-cookies-07

Chrome will be releasing these changes on February: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html