### PR TITLE
Fix Luarocks download failure

### DIFF
--- a/rockspecs/lua-resty-cookie-0.1.0-2.rockspec
+++ b/rockspecs/lua-resty-cookie-0.1.0-2.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-cookie"
-version = "0.1.0-1"
+version = "0.1.0-2"
 
 source = {
-  url = "git://github.com/cloudflare/lua-resty-cookie.git",
+  url = "https://github.com/cloudflare/lua-resty-cookie.git",
   tag = "v0.1.0",
 }
 

--- a/rockspecs/lua-resty-cookie-scm-1.rockspec
+++ b/rockspecs/lua-resty-cookie-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "lua-resty-cookie"
 version = "scm-1"
 
 source = {
-  url = "git://github.com/cloudflare/lua-resty-cookie.git",
+  url = "https://github.com/cloudflare/lua-resty-cookie.git",
 }
 
 description = {


### PR DESCRIPTION
Currently luarocks install lua-resty-cookie fails with this error:

```
luarocks install lua-resty-cookie
Installing https://luarocks.org/lua-resty-cookie-0.1.0-1.rockspec
Cloning into 'lua-resty-cookie'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Error: Failed cloning git repository.
```

This is happening because github is no longer supporting direct-linking
to releases using the git:// protocol. The fix is easy - replace with
https.

In order to fix this completely someone with the right Luarocks key
should do:

```
luarocks upload rockspecs/lua-resty-cookie-0.1.0-2.rockspec --api-key $KEY
```

Thanks and have a good day.
